### PR TITLE
Show patches without patch-type or range-patch.

### DIFF
--- a/examples/2a/client.js
+++ b/examples/2a/client.js
@@ -1,0 +1,12 @@
+const {subscribe} = require('@josephg/braid-client')
+
+;(async () => {
+  const {initialValue, stream} = 
+    await subscribe('http://localhost:2002/doc', {
+      applyPatch: () => console.log('received patch')
+    })
+  console.log(initialValue)
+  for await (const data of stream) {
+    console.log(data.value)
+  }
+})()

--- a/examples/2a/package.json
+++ b/examples/2a/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "example2a",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "dependencies": {
+    "@josephg/braid-client": "*",
+    "@josephg/braid-server": "*",
+    "polka": "^0.5.2",
+    "ot-fuzzer": "^1.3.0",
+    "ot-text-unicode": "^4.0.0"
+  }
+}

--- a/examples/2a/server.js
+++ b/examples/2a/server.js
@@ -1,0 +1,38 @@
+const polka = require('polka')
+const braid = require('@josephg/braid-server')
+
+let doc = []
+
+// Set of clients to be updated.
+const clients = new Set()
+
+// Every 5 seconds update the document and send its entirety as a patch
+// Note: in practice, this would be better as a range-patch because you
+// would need to only send a "delta" of what changed; however, this example
+// is for testing simple streaming patches, and the simplest patch is to
+// send the whole doc again.
+setInterval(() => {
+  doc.push({ item: doc.length })
+  for (const c of clients) {
+    c.append({
+      data: JSON.stringify(doc) + '\n',
+    })
+  }
+}, 5000)
+
+polka()
+  .get('/doc', (req, res) => {
+    const stream = braid.stream(res, {
+      reqHeaders: req.headers,
+      initialValue: JSON.stringify(doc) + '\n',
+      contentType: 'application/json',
+      onclose() {
+        if (stream) clients.delete(stream)
+      },
+    })
+    if (stream) clients.add(stream)
+  })
+  .listen(2002, (err) => {
+    if (err) throw err
+    console.log('listening on http://localhost:2002/doc')
+  })


### PR DESCRIPTION
Is this the simplest case for sending patches across the wire? I'd like to show a braid subscription with patches but without patch-type or range-patch.